### PR TITLE
Add websocket metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All options can be either configured via command line flags, or via their respec
 To get a list of all the options, run `wg-manager -h`.
 
 When installed via the `.deb` package, a user named `wireguard-manager` will be created for the service to run as, as well as a systemd service named `wireguard-manager.service`.
+The name of the binary when installed via the `.deb` package is `wireguard-manager`.
 Configuration is done by creating a file at `/etc/default/wireguard-manager` and defining the environment variables there.
 All logs are sent to stdout/stderr, so in order to debug issues with the service, simply use `journalctl` or `systemctl status`.
 

--- a/api/subscriber/subscriber_test.go
+++ b/api/subscriber/subscriber_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/infosum/statsd"
 	"github.com/mullvad/wg-manager/api"
 	"github.com/mullvad/wg-manager/api/subscriber"
 	"nhooyr.io/websocket"
@@ -60,11 +61,17 @@ func TestSubscriber(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	metrics, err := statsd.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	s := subscriber.Subscriber{
 		BaseURL:  "ws://" + parsedURL.Host,
 		Channel:  "test",
 		Username: username,
 		Password: password,
+		Metrics:  metrics,
 	}
 
 	channel := make(chan subscriber.WireguardEvent)

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func main() {
 		Password: *mqPassword,
 		BaseURL:  *mqURL,
 		Channel:  *mqChannel,
+		Metrics:  metrics,
 	}
 	eventChannel := make(chan subscriber.WireguardEvent)
 	defer close(eventChannel)

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		Password: *password,
 		BaseURL:  *url,
 		Client: &http.Client{
-			Timeout: time.Second * 10, // By default http.Client doesn't have a timeout, so specify a reasonable one
+			Timeout: time.Second * 15, // By default http.Client doesn't have a timeout, so specify a reasonable one
 		},
 	}
 

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -5,7 +5,7 @@ version: "${VERSION}"
 maintainer: Mullvad Developers
 bindir: "/usr/local/bin"
 files:
-  ./wg-manager: "/usr/local/bin/wg-manager"
+  ./wg-manager: "/usr/local/bin/wireguard-manager"
 config_files:
   ./packaging/wireguard-manager.service: "/etc/systemd/system/wireguard-manager.service"
 overrides:

--- a/packaging/wireguard-manager.service
+++ b/packaging/wireguard-manager.service
@@ -7,7 +7,7 @@ StartLimitIntervalSec=0
 User=wireguard-manager
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
 EnvironmentFile=/etc/default/wireguard-manager
-ExecStart=/usr/local/bin/wg-manager
+ExecStart=/usr/local/bin/wireguard-manager
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
Also changes the binary name back to `wireguard-manager` for our .deb package to keep backwards compatibility (since we now pgrep for the process, etc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wg-manager/13)
<!-- Reviewable:end -->
