### PR TITLE
Wireguard connection report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,12 @@ script:
   - sudo apt-get -y update
   - sudo apt-get -y install linux-headers-$(uname -r) wireguard-dkms ipset
   - sudo ip link add wg0 type wireguard
+  - sudo ip link add wg1 type wireguard
   - sudo ip link set up wg0
+  - sudo ip link set up wg1
+  # Set up peer addresses for the interfaces
+  - sudo ip address add dev wg0 10.99.0.1 peer 10.99.0.2
+  - sudo ip address add dev wg1 10.99.0.2 peer 10.99.0.1
   # Build the project and run the tests
   - make
   # Set up iptables

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ This will produce a `wg-manager` binary and put them in your `GOBIN`.
 
 ## Testing
 To run the tests, run `make test`.
-To run the integration tests as well, run `go test ./...`. Note that this requires WireGuard to be running on the machine, and root privileges.
+
+To run the integration tests as well, look at the `.travis`-file in the repository to see the prerequisite steps to be able to run them. After which you can run `go test ./...`. Note that this requires WireGuard to be running on the machine, and root privileges.
 
 ### Testing iptables using network namespaces
 To test iptables without messing with your system configuration, you can use network namespaces.
-To set one up and enter it, run the following commands:
+To set one up, enter it and allow localhost routing, run the following commands:
 
 ```
 sudo ip netns add wg-test
 sudo -E env "PATH=$PATH" nsenter --net=/var/run/netns/wg-test
+ip link set up lo
 ```
 
 Then you can run the tests as described above.

--- a/api/api.go
+++ b/api/api.go
@@ -30,7 +30,7 @@ type WireguardPeer struct {
 // ConnectedKeyList contains connected keys
 type ConnectedKeyList []ConnectedKey
 
-// ConnectedKey contains a wireguard public key and the number of connections using siad key
+// ConnectedKey contains a wireguard public key and the number of connections using said key
 type ConnectedKey struct {
 	Pubkey      string `json:"key"`
 	Connections int    `json:"connections"`

--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,7 @@ func (a *API) GetWireguardPeers() (WireguardPeerList, error) {
 		return WireguardPeerList{}, err
 	}
 
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Relay-Hostname", a.Hostname)
 
 	if a.Username != "" && a.Password != "" {
@@ -74,6 +75,7 @@ func (a *API) PostWireguardConnections(keys ConnectedKeysMap) error {
 		return err
 	}
 
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Relay-Hostname", a.Hostname)
 
 	if a.Username != "" && a.Password != "" {

--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,11 @@ type WireguardPeer struct {
 	Pubkey string `json:"pubkey"`
 }
 
+// ConnectedKeys contain connected keys
+type ConnectedKeys struct {
+	Keys []string `json:"keys"`
+}
+
 // GetWireguardPeers fetches a list of wireguard peers from the API and returns it
 func (a *API) GetWireguardPeers() (WireguardPeerList, error) {
 	req, err := http.NewRequest("GET", a.BaseURL+"/wg/active-pubkeys/v2/", nil)

--- a/api/api.go
+++ b/api/api.go
@@ -27,14 +27,8 @@ type WireguardPeer struct {
 	Pubkey string `json:"pubkey"`
 }
 
-// ConnectedKeyList contains connected keys
-type ConnectedKeyList []ConnectedKey
-
-// ConnectedKey contains a wireguard public key and the number of connections using said key
-type ConnectedKey struct {
-	Pubkey      string `json:"key"`
-	Connections int    `json:"connections"`
-}
+// ConnectedKeysMap contains connected keys and their respective numer of keys
+type ConnectedKeysMap map[string]int
 
 // GetWireguardPeers fetches a list of wireguard peers from the API and returns it
 func (a *API) GetWireguardPeers() (WireguardPeerList, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -68,8 +68,11 @@ func (a *API) GetWireguardPeers() (WireguardPeerList, error) {
 
 // PostWireguardConnections posts the number of connected wireguard keys to the API
 func (a *API) PostWireguardConnections(keys ConnectedKeysMap) error {
+	connectionsMap := make(map[string]ConnectedKeysMap)
+	connectionsMap["connections"] = keys
+
 	buffer := new(bytes.Buffer)
-	json.NewEncoder(buffer).Encode(keys)
+	json.NewEncoder(buffer).Encode(connectionsMap)
 	req, err := http.NewRequest("POST", a.BaseURL+"/internal/wireguard-connection-report/", buffer)
 	if err != nil {
 		return err

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -62,4 +63,29 @@ func (a *API) GetWireguardPeers() (WireguardPeerList, error) {
 	}
 
 	return decodedResponse, nil
+}
+
+// PostWireguardConnections posts the number of connected wireguard keys to the API
+func (a *API) PostWireguardConnections(keys ConnectedKeysMap) error {
+	buffer := new(bytes.Buffer)
+	json.NewEncoder(buffer).Encode(keys)
+	req, err := http.NewRequest("POST", a.BaseURL+"/internal/wireguard-connection-report/", buffer)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Relay-Hostname", a.Hostname)
+
+	if a.Username != "" && a.Password != "" {
+		req.SetBasicAuth(a.Username, a.Password)
+	}
+
+	response, err := a.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	return nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -27,9 +27,13 @@ type WireguardPeer struct {
 	Pubkey string `json:"pubkey"`
 }
 
-// ConnectedKeys contain connected keys
-type ConnectedKeys struct {
-	Keys []string `json:"keys"`
+// ConnectedKeyList contains connected keys
+type ConnectedKeyList []ConnectedKey
+
+// ConnectedKey contains a wireguard public key and the number of connections using siad key
+type ConnectedKey struct {
+	Pubkey      string `json:"key"`
+	Connections int    `json:"connections"`
 }
 
 // GetWireguardPeers fetches a list of wireguard peers from the API and returns it

--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ type API struct {
 	Username string
 	Password string
 	BaseURL  string
+	Hostname string
 	Client   *http.Client
 }
 
@@ -33,10 +34,12 @@ type ConnectedKeys struct {
 
 // GetWireguardPeers fetches a list of wireguard peers from the API and returns it
 func (a *API) GetWireguardPeers() (WireguardPeerList, error) {
-	req, err := http.NewRequest("GET", a.BaseURL+"/wg/active-pubkeys/v2/", nil)
+	req, err := http.NewRequest("GET", a.BaseURL+"/internal/active-wireguard-peers/", nil)
 	if err != nil {
 		return WireguardPeerList{}, err
 	}
+
+	req.Header.Add("X-Relay-Hostname", a.Hostname)
 
 	if a.Username != "" && a.Password != "" {
 		req.SetBasicAuth(a.Username, a.Password)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -27,6 +27,10 @@ var connectedKeysFixture = api.ConnectedKeysMap{
 	strings.Repeat("b", 32): 2,
 }
 
+var connectionsFixture = map[string]api.ConnectedKeysMap{
+	"connections": connectedKeysFixture,
+}
+
 func TestGetWireguardPeers(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		bytes, _ := json.Marshal(peerFixture)
@@ -61,14 +65,14 @@ func TestPostWireguardPeers(t *testing.T) {
 			t.Fatalf(err.Error())
 		}
 
-		var connectedKeys api.ConnectedKeysMap
+		var connectedKeys map[string]api.ConnectedKeysMap
 		err = json.Unmarshal(body, &connectedKeys)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
 
-		if !reflect.DeepEqual(connectedKeys, connectedKeysFixture) {
-			t.Errorf("got unexpected result, wanted %+v, got %+v", connectedKeys, connectedKeysFixture)
+		if !reflect.DeepEqual(connectedKeys, connectionsFixture) {
+			t.Errorf("got unexpected result, wanted %+v, got %+v", connectedKeys, connectionsFixture)
 		}
 
 		rw.WriteHeader(http.StatusOK)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -35,6 +35,7 @@ func TestAPI(t *testing.T) {
 		Client:   server.Client(),
 		Username: "foo",
 		Password: "bar",
+		Hostname: "test",
 	}
 
 	peers, err := api.GetWireguardPeers()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/mullvad/wg-manager/api"
 )
 
-var fixture = api.WireguardPeerList{
+var peerFixture = api.WireguardPeerList{
 	api.WireguardPeer{
 		IPv4:   "10.99.0.1/32",
 		IPv6:   "fc00:bbbb:bbbb:bb01::1/128",
@@ -21,9 +22,14 @@ var fixture = api.WireguardPeerList{
 	},
 }
 
-func TestAPI(t *testing.T) {
+var connectedKeysFixture = api.ConnectedKeysMap{
+	strings.Repeat("a", 32): 1,
+	strings.Repeat("b", 32): 2,
+}
+
+func TestGetWireguardPeers(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		bytes, _ := json.Marshal(fixture)
+		bytes, _ := json.Marshal(peerFixture)
 		rw.Write(bytes)
 	}))
 	// Close the server when test finishes
@@ -43,7 +49,51 @@ func TestAPI(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	if !reflect.DeepEqual(peers, fixture) {
-		t.Errorf("got unexpected result, wanted %+v, got %+v", peers, fixture)
+	if !reflect.DeepEqual(peers, peerFixture) {
+		t.Errorf("got unexpected result, wanted %+v, got %+v", peers, peerFixture)
+	}
+}
+
+func TestPostWireguardPeers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		var connectedKeys api.ConnectedKeysMap
+		err = json.Unmarshal(body, &connectedKeys)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		if !reflect.DeepEqual(connectedKeys, connectedKeysFixture) {
+			t.Errorf("got unexpected result, wanted %+v, got %+v", connectedKeys, connectedKeysFixture)
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	}))
+	// Close the server when test finishes
+	defer server.Close()
+
+	// Use Client & URL from our local test server
+	a := api.API{
+		BaseURL:  server.URL,
+		Client:   server.Client(),
+		Username: "foo",
+		Password: "bar",
+		Hostname: "test",
+	}
+
+	// Create a copy so that we don't alter the fixture
+	connectedKeysCopy := make(api.ConnectedKeysMap)
+
+	for k, v := range connectedKeysFixture {
+		connectedKeysCopy[k] = v
+	}
+
+	err := a.PostWireguardConnections(connectedKeysCopy)
+	if err != nil {
+		t.Fatalf(err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -174,12 +174,21 @@ func synchronize() {
 	t.Send("get_wireguard_peers_time")
 
 	t = metrics.NewTiming()
-	wg.UpdatePeers(peers)
+	connectedKeys := wg.UpdatePeers(peers)
 	t.Send("update_peers_time")
 
 	t = metrics.NewTiming()
 	pf.UpdatePortforwarding(peers)
 	t.Send("update_portforwarding_time")
+
+	t = metrics.NewTiming()
+	err = a.PostWireguardConnections(connectedKeys)
+	if err != nil {
+		metrics.Increment("error_posting_connections")
+		log.Printf("error posting connections %s", err.Error())
+		return
+	}
+	t.Send("post_wireguard_connections_time")
 }
 
 func waitForInterrupt(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	url := flag.String("url", "https://example.com", "api url")
 	username := flag.String("username", "", "api username")
 	password := flag.String("password", "", "api password")
+	hostname := flag.String("hostname", "", "server hostname")
 	interfaces := flag.String("interfaces", "wg0", "wireguard interfaces to configure. Pass a comma delimited list to configure multiple interfaces, eg 'wg0,wg1,wg2'")
 	portForwardingChain := flag.String("portforwarding-chain", "PORTFORWARDING", "iptables chain to use for portforwarding")
 	portForwardingIpsetIPv4 := flag.String("portforwarding-ipset-ipv4", "PORTFORWARDING_IPV4", "ipset table to use for portforwarding for ipv4 addresses.")
@@ -77,6 +78,7 @@ func main() {
 		Username: *username,
 		Password: *password,
 		BaseURL:  *url,
+		Hostname: *hostname,
 		Client: &http.Client{
 			Timeout: *apiTimeout,
 		},

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -201,7 +201,7 @@ func mapExistingPeers(peers []wgtypes.Peer) (peerMap map[wgtypes.Key]wgtypes.Pee
 const handshakeInterval = time.Minute * 2
 
 // How long since a handshake to consider the peer as connected
-const connectedInterval = time.Minute * 5
+const connectedInterval = time.Minute * 3
 
 // Count the connected wireguard peers
 func countConnectedPeers(peers []wgtypes.Peer) (devicePeerCount int, deviceConnectedKeys []wgtypes.Key) {

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -138,10 +138,10 @@ func TestWireguard(t *testing.T) {
 	t.Run("check connected keys", func(t *testing.T) {
 		connectedKeys := wg.UpdatePeers(apiFixture)
 
-		expectedKeys := api.ConnectedKeys{
-			Keys: []string{
-				wgClientPrivkey.PublicKey().String(),
-			},
+		expectedKeys := api.ConnectedKeyList{api.ConnectedKey{
+			Pubkey:      wgClientPrivkey.PublicKey().String(),
+			Connections: 1,
+		},
 		}
 
 		if diff := cmp.Diff(expectedKeys, connectedKeys); diff != "" {

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -138,10 +138,8 @@ func TestWireguard(t *testing.T) {
 	t.Run("check connected keys", func(t *testing.T) {
 		connectedKeys := wg.UpdatePeers(apiFixture)
 
-		expectedKeys := api.ConnectedKeyList{api.ConnectedKey{
-			Pubkey:      wgClientPrivkey.PublicKey().String(),
-			Connections: 1,
-		},
+		expectedKeys := api.ConnectedKeysMap{
+			wgClientPrivkey.PublicKey().String(): 1,
 		}
 
 		if diff := cmp.Diff(expectedKeys, connectedKeys); diff != "" {

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/infosum/statsd"
@@ -18,8 +19,14 @@ import (
 // Requires a wireguard interface named wg0 to be running on the system
 
 const testInterface = "wg0"
+const testClientInterface = "wg1"
 
-var ipv4Net = net.ParseIP("10.99.0.0")
+var listenPort int = 4200
+var keepAliveInterval = time.Second
+
+var _, ipv4Net, _ = net.ParseCIDR("10.99.0.1/32")
+var _, ipv4ClientNet, _ = net.ParseCIDR("10.99.0.2/32")
+var ipv4IP = net.ParseIP("10.99.0.1")
 var ipv6Net = net.ParseIP("fc00:bbbb:bbbb:bb01::")
 
 var apiFixture = api.WireguardPeerList{
@@ -35,7 +42,7 @@ var peerFixture = []wgtypes.Peer{{
 	PublicKey: wgKey(),
 	AllowedIPs: []net.IPNet{
 		net.IPNet{
-			IP:   net.ParseIP("10.99.0.1"),
+			IP:   ipv4IP,
 			Mask: net.CIDRMask(32, 32),
 		},
 		net.IPNet{
@@ -69,13 +76,81 @@ func TestWireguard(t *testing.T) {
 	defer client.Close()
 	defer resetDevice(t, client)
 
+	wgPrivkey, _ := wgtypes.GeneratePrivateKey()
+	wgClientPrivkey, _ := wgtypes.GeneratePrivateKey()
+	wgExtrakey, _ := wgtypes.GenerateKey()
+
+	err = client.ConfigureDevice(testInterface, wgtypes.Config{
+		PrivateKey:   &wgPrivkey,
+		ListenPort:   &listenPort,
+		ReplacePeers: true,
+		Peers: []wgtypes.PeerConfig{
+			// Peer that will get a handshake
+			wgtypes.PeerConfig{
+				PublicKey:         wgClientPrivkey.PublicKey(),
+				ReplaceAllowedIPs: true,
+				AllowedIPs: []net.IPNet{
+					*ipv4ClientNet,
+				},
+			},
+			// Peer that will not get a handshake
+			wgtypes.PeerConfig{
+				PublicKey: wgExtrakey,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.ConfigureDevice(testClientInterface, wgtypes.Config{
+		PrivateKey:   &wgClientPrivkey,
+		ReplacePeers: true,
+		Peers: []wgtypes.PeerConfig{
+			// Peer that will connect to the wireguard test interface
+			wgtypes.PeerConfig{
+				PublicKey:         wgPrivkey.PublicKey(),
+				ReplaceAllowedIPs: true,
+				AllowedIPs: []net.IPNet{
+					*ipv4Net,
+				},
+				Endpoint: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"),
+					Port: listenPort},
+				PersistentKeepaliveInterval: &keepAliveInterval,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sleep so that there's time for a handshake between the peers
+	time.Sleep(time.Second * 2)
+
 	wg, err := wireguard.New([]string{testInterface}, metrics)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer wg.Close()
 
+	t.Run("check connected keys", func(t *testing.T) {
+		connectedKeys := wg.UpdatePeers(apiFixture)
+
+		expectedKeys := api.ConnectedKeys{
+			Keys: []string{
+				wgClientPrivkey.PublicKey().String(),
+			},
+		}
+
+		if diff := cmp.Diff(expectedKeys, connectedKeys); diff != "" {
+			t.Fatalf("unexpected keys (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("add peers", func(t *testing.T) {
+
 		wg.UpdatePeers(apiFixture)
 
 		device, err := client.Device(testInterface)


### PR DESCRIPTION
This is the wireguard part for being able report what we deem as connected wireguard keys. I'm still working on the API part of this which will be pushed in a later commit, but just to be able to get your initial feedback on the parts that are already done I'm creating a PR now.

I've also updated the documentation for running the integration tests and updated our travis configuration, so fingers crossed the tests should pass on travis as well and not just locally :crossed_fingers:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wg-manager/17)
<!-- Reviewable:end -->
