### PR TITLE
Updateportforwarding event

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,6 +157,8 @@ func handleEvent(event subscriber.WireguardEvent) {
 	case "REMOVE":
 		wg.RemovePeer(event.Peer)
 		pf.RemovePortforwarding(event.Peer)
+	case "UPDATEPORTFORWARD":
+		pf.UpdateSinglePeerPortforwarding(event.Peer)
 	default: // Bad data from the API, ignore it
 	}
 }

--- a/main.go
+++ b/main.go
@@ -150,15 +150,26 @@ func main() {
 }
 
 func handleEvent(event subscriber.WireguardEvent) {
+
 	switch event.Action {
 	case "ADD":
+		t := metrics.NewTiming()
 		wg.AddPeer(event.Peer)
+		t.Send("add_event_add_peer_time")
+		t = metrics.NewTiming()
 		pf.AddPortforwarding(event.Peer)
+		t.Send("add_event_add_portforwarding_time")
 	case "REMOVE":
+		t := metrics.NewTiming()
 		wg.RemovePeer(event.Peer)
+		t.Send("remove_event_remove_peer_time")
+		t = metrics.NewTiming()
 		pf.RemovePortforwarding(event.Peer)
+		t.Send("remove_event_remove_portforwarding_time")
 	case "UPDATE_PORTS":
+		t := metrics.NewTiming()
 		pf.UpdateSinglePeerPortforwarding(event.Peer)
+		t.Send("update_ports_event_update_portforwarding_time")
 	default: // Bad data from the API, ignore it
 	}
 }

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func handleEvent(event subscriber.WireguardEvent) {
 	case "REMOVE":
 		wg.RemovePeer(event.Peer)
 		pf.RemovePortforwarding(event.Peer)
-	case "UPDATEPORTFORWARD":
+	case "UPDATE_PORTS":
 		pf.UpdateSinglePeerPortforwarding(event.Peer)
 	default: // Bad data from the API, ignore it
 	}

--- a/portforward/portforward.go
+++ b/portforward/portforward.go
@@ -271,10 +271,10 @@ func (p *Portforward) removeOldPeerRules(peer api.WireguardPeer, protocol iptabl
 		sameRule := oldRule == rule
 		addressIPv4, _, _ := net.ParseCIDR(peer.IPv4)
 		addressIPv6, _, _ := net.ParseCIDR(peer.IPv6)
-		sameDestinationIPV4 := strings.Contains(oldRule, addressIPv4.String())
-		sameDestinationIPV6 := strings.Contains(oldRule, addressIPv6.String())
+		oldRuleSlice := strings.Split(oldRule, " ")
+		oldIP := net.ParseIP(oldRuleSlice[len(oldRuleSlice)-1])
 
-		if !sameRule && (sameDestinationIPV4 || sameDestinationIPV6) {
+		if !sameRule && (oldIP.Equal(addressIPv4) || oldIP.Equal(addressIPv6)) {
 			err := ipt.Delete(table, chain, strings.Split(oldRule, " ")...)
 			if err != nil {
 				log.Printf("error deleting iptables rule")

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -235,7 +235,7 @@ func (w *Wireguard) AddPeer(peer api.WireguardPeer) {
 		// Add the peer
 		err := w.client.ConfigureDevice(d, wgtypes.Config{
 			Peers: []wgtypes.PeerConfig{
-				wgtypes.PeerConfig{
+				{
 					PublicKey:         key,
 					ReplaceAllowedIPs: true,
 					AllowedIPs: []net.IPNet{
@@ -264,7 +264,7 @@ func (w *Wireguard) RemovePeer(peer api.WireguardPeer) {
 		// Remove the peer
 		err := w.client.ConfigureDevice(d, wgtypes.Config{
 			Peers: []wgtypes.PeerConfig{
-				wgtypes.PeerConfig{
+				{
 					PublicKey: key,
 					Remove:    true,
 				},

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -41,11 +41,11 @@ var apiFixture = api.WireguardPeerList{
 var peerFixture = []wgtypes.Peer{{
 	PublicKey: wgKey(),
 	AllowedIPs: []net.IPNet{
-		net.IPNet{
+		{
 			IP:   ipv4IP,
 			Mask: net.CIDRMask(32, 32),
 		},
-		net.IPNet{
+		{
 			IP:   net.ParseIP("fc00:bbbb:bbbb:bb01::1"),
 			Mask: net.CIDRMask(128, 128),
 		},
@@ -86,7 +86,7 @@ func TestWireguard(t *testing.T) {
 		ReplacePeers: true,
 		Peers: []wgtypes.PeerConfig{
 			// Peer that will get a handshake
-			wgtypes.PeerConfig{
+			{
 				PublicKey:         wgClientPrivkey.PublicKey(),
 				ReplaceAllowedIPs: true,
 				AllowedIPs: []net.IPNet{
@@ -94,7 +94,7 @@ func TestWireguard(t *testing.T) {
 				},
 			},
 			// Peer that will not get a handshake
-			wgtypes.PeerConfig{
+			{
 				PublicKey: wgExtrakey,
 			},
 		},
@@ -109,7 +109,7 @@ func TestWireguard(t *testing.T) {
 		ReplacePeers: true,
 		Peers: []wgtypes.PeerConfig{
 			// Peer that will connect to the wireguard test interface
-			wgtypes.PeerConfig{
+			{
 				PublicKey:         wgPrivkey.PublicKey(),
 				ReplaceAllowedIPs: true,
 				AllowedIPs: []net.IPNet{


### PR DESCRIPTION
This will let us add redis pubsub events to just update portforwarding. We went for the approach of removing old ports in use by the same peer IP. Also the implementation only requires the same peer datastructure as the other events, no need for old ports to remove as discussed previously.

As you can see we also changed the way we apply iptables rules to use `insert` rather than `append` so that if there should be any old rules present using the same port anyway (perhaps due to the server not properly receiving a portforwarding event for another peer), the latest added one will take precedence.

We also tried a much simpler approach where we just changed the old `AddPortforwarding` to use `insert` for iptables without trying to remove any old ports. That seems to work, and the code for that only requires a change on one line, but if we want to move wg-manager to be less reliant on polling for cleanup, it might be worth the extra complexity this PR adds.

Based this on the portforwarding-chain-split PR, since that also updates dependencies, travis and tests a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wg-manager/20)
<!-- Reviewable:end -->
