### PR TITLE
Increase wireguard event channel buffer size

### DIFF
--- a/api/subscriber/subscriber_test.go
+++ b/api/subscriber/subscriber_test.go
@@ -74,7 +74,7 @@ func TestSubscriber(t *testing.T) {
 		Metrics:  metrics,
 	}
 
-	channel := make(chan subscriber.WireguardEvent)
+	channel := make(chan subscriber.WireguardEvent, 1024)
 	defer close(channel)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 		Channel:  *mqChannel,
 		Metrics:  metrics,
 	}
-	eventChannel := make(chan subscriber.WireguardEvent)
+	eventChannel := make(chan subscriber.WireguardEvent, 1024)
 	defer close(eventChannel)
 
 	err = s.Subscribe(shutdownCtx, eventChannel)


### PR DESCRIPTION
Used to tests whether it remedies websocket ping errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wg-manager/23)
<!-- Reviewable:end -->
