### PR TITLE
Move peer handshake resets out of UpdatePeers and into new method Res…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ integration-test:
 	go test -v ./...
 
 docker-test: .make/docker_local_testing
-	docker run --rm -it --cap-add CAP_NET_ADMIN,CAP_NET_RAW -v ${PWD}:/repo ${DOCKER_TEST_IMAGE} bash -c "./setup_testing_environment.sh; gotestsum --format standard-verbose; gotestsum --format standard-verbose --watch"
+	docker run --rm -it --cap-add NET_ADMIN --cap-add NET_RAW -v ${PWD}:/repo ${DOCKER_TEST_IMAGE} bash -c "./setup_testing_environment.sh; gotestsum --format standard-verbose; gotestsum --format standard-verbose --watch"
 
 ci: vet test
 	sudo ./setup_testing_environment.sh

--- a/main.go
+++ b/main.go
@@ -118,6 +118,9 @@ func main() {
 	// Run an initial synchronization
 	synchronize()
 
+	// Run an initial count of peers
+	countPeers()
+
 	// Set up a connection to receive add/remove events
 	s := subscriber.Subscriber{
 		Username: *mqUsername,

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 				// This way we don't need a mutex or similar to ensure it doesn't run concurrently either
 				synchronize()
 			case <-resetHandshakeTicker.C:
-
+				resetHandshake()
 			case <-shutdownCtx.Done():
 				synchronizationTicker.Stop()
 				resetHandshakeTicker.Stop()

--- a/main.go
+++ b/main.go
@@ -152,6 +152,7 @@ func main() {
 				// We run this synchronously, the ticker will drop ticks if this takes too long
 				// This way we don't need a mutex or similar to ensure it doesn't run concurrently either
 				synchronize()
+				metrics.Gauge("eventchannel_length", len(eventChannel))
 			case <-resetHandshakeTicker.C:
 				resetHandshake()
 			case <-shutdownCtx.Done():

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -48,7 +48,7 @@ func (w *Wireguard) ResetPeers() {
 		addPeers := []wgtypes.PeerConfig{}
 		dev, err := w.client.Device(d)
 		if err != nil {
-			// TODO: Add some kind of useful error message
+			log.Printf("error connecting to wireguard interface %s: %s", d, err.Error())
 			continue
 		}
 		peers := dev.Peers
@@ -83,7 +83,7 @@ func (w *Wireguard) ResetPeers() {
 			continue
 		}
 
-		// Add new peers, remove deleted peers, and remove peers should be reset
+		// Remove peers that should be reset
 		err = w.client.ConfigureDevice(d, wgtypes.Config{
 			Peers: removePeers,
 		})

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -57,20 +57,9 @@ func (w *Wireguard) ResetPeers() {
 					Remove:    true,
 				})
 
-				// Copy the preshared key if one is set
-				var emptyKey wgtypes.Key
-				var copiedKey wgtypes.Key
-				// TODO: Can we just get rid of presharedkey handling alltogether?
-				if peer.PresharedKey != emptyKey {
-					// TODO: Is this still the case? Perhaps it's now fixed upstream?
-					// We need to copy the key, or the pointer gets corrupted for some reason
-					copy(copiedKey[:], peer.PresharedKey[:])
-				}
-
 				addPeers = append(addPeers, wgtypes.PeerConfig{
 					PublicKey:         peer.PublicKey,
 					ReplaceAllowedIPs: true,
-					PresharedKey:      &copiedKey,
 					AllowedIPs:        peer.AllowedIPs,
 				})
 			}

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -130,13 +130,12 @@ func TestWireguard(t *testing.T) {
 	defer wg.Close()
 
 	t.Run("check connected keys", func(t *testing.T) {
-		connectedKeys := wg.UpdatePeers(apiFixture)
+		wg.UpdatePeers(apiFixture)
 
-		expectedKeys := api.ConnectedKeysMap{
-			wgClientPrivkey.PublicKey().String(): 1,
-		}
+		// Since we do not get any handshakes from any peers, this should return nothing
+		connectedKeys, _ := wg.CountPeers()
 
-		if diff := cmp.Diff(expectedKeys, connectedKeys); diff != "" {
+		if diff := cmp.Diff(api.ConnectedKeysMap{}, connectedKeys); diff != "" {
 			t.Fatalf("unexpected keys (-want +got):\n%s", diff)
 		}
 	})

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -179,6 +179,23 @@ func TestWireguard(t *testing.T) {
 		}
 	})
 
+	t.Run("reset handshakes", func(t *testing.T) {
+		// Since we do not connect with any peers this should do nothing
+		wg.ResetPeers()
+
+		device, err := client.Device(testInterface)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		peerFixture[0].AllowedIPs[0].IP = net.ParseIP("10.99.0.2")
+		peerFixture[0].AllowedIPs[1].IP = net.ParseIP("fc00:bbbb:bbbb:bb01::2")
+
+		if diff := cmp.Diff(peerFixture, device.Peers); diff != "" {
+			t.Fatalf("unexpected peers (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("remove peers", func(t *testing.T) {
 		wg.UpdatePeers(api.WireguardPeerList{})
 

--- a/wireguard/wireguard_test.go
+++ b/wireguard/wireguard_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/infosum/statsd"
 	"github.com/mullvad/wg-manager/api"
 	"github.com/mullvad/wg-manager/wireguard"
 	"golang.zx2c4.com/wireguard/wgctrl"
@@ -61,11 +60,6 @@ func wgKey() wgtypes.Key {
 func TestWireguard(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration tests")
-	}
-
-	metrics, err := statsd.New()
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	client, err := wgctrl.New()
@@ -129,7 +123,7 @@ func TestWireguard(t *testing.T) {
 	// Sleep so that there's time for a handshake between the peers
 	time.Sleep(time.Second * 2)
 
-	wg, err := wireguard.New([]string{testInterface}, metrics)
+	wg, err := wireguard.New([]string{testInterface})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +249,7 @@ func TestInvalidInterface(t *testing.T) {
 
 	interfaceName := "nonexistant"
 
-	_, err := wireguard.New([]string{interfaceName}, nil)
+	_, err := wireguard.New([]string{interfaceName})
 	if err == nil {
 		t.Fatal("no error")
 	}


### PR DESCRIPTION
…etPeers

This should reduce the time UpdatePeers needs to run, and allow us to reset handshake more often.

Marking as draft since this still has some `TODO`:s that need investigating/fixing, some tests still need to be performed and we might want to refactor out connection reporting as part of this PR as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wg-manager/24)
<!-- Reviewable:end -->
