### PR TITLE
Graceful shutdown suggestions

### DIFF
--- a/api/subscriber/subscriber.go
+++ b/api/subscriber/subscriber.go
@@ -104,8 +104,11 @@ func (s *Subscriber) reconnect(ctx context.Context) error {
 		case <-ticker.C:
 			err = s.connect(ctx)
 			if err == nil {
+				log.Println("successfully reconnected to websocket")
+				s.Metrics.Increment("websocket_reconnect_success")
 				return nil
 			}
+			s.Metrics.Increment("websocket_reconnect_error")
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/api/subscriber/subscriber.go
+++ b/api/subscriber/subscriber.go
@@ -82,7 +82,7 @@ func (s *Subscriber) read(ctx context.Context) {
 
 			// Start attempting to reconnect
 			err = s.reconnect(ctx)
-			if err != nil { // Reconnect failed which is a context cancel/timeout here
+			if err != nil { // Reconnect failed (context closed)
 				close(s.eventCh)
 				return
 			}
@@ -94,6 +94,7 @@ func (s *Subscriber) read(ctx context.Context) {
 	}
 }
 
+// reconnect try to init a new connection unless the context is closed
 func (s *Subscriber) reconnect(ctx context.Context) error {
 	ticker := time.NewTicker(1 * time.Second)
 

--- a/api/subscriber/subscriber_test.go
+++ b/api/subscriber/subscriber_test.go
@@ -74,13 +74,13 @@ func TestSubscriber(t *testing.T) {
 		Metrics:  metrics,
 	}
 
-	channel := make(chan subscriber.WireguardEvent, 1024)
-	defer close(channel)
+	// channel := make(chan subscriber.WireguardEvent, 1024)
+	// defer close(channel)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err = s.Subscribe(ctx, channel)
+	channel, err := s.Subscribe(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,4 +93,75 @@ func TestSubscriber(t *testing.T) {
 			t.Errorf("got unexpected result, wanted %+v, got %+v", msg, fixture)
 		}
 	}
+}
+
+func TestSubscriberReconnect(t *testing.T) {
+	var reject bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if reject {
+			return
+		}
+
+		u, p, ok := r.BasicAuth()
+		if !ok || u != username || p != password {
+			t.Fatal("invalid credentials")
+		}
+
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second*10)
+		defer cancel()
+
+		err = wsjson.Write(ctx, c, fixture)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c.Close(websocket.StatusNormalClosure, "")
+		reject = true
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := statsd.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := subscriber.Subscriber{
+		BaseURL:  "ws://" + parsedURL.Host,
+		Channel:  "test",
+		Username: username,
+		Password: password,
+		Metrics:  metrics,
+	}
+
+	//channel := make(chan subscriber.WireguardEvent, 1024)
+	//defer close(channel)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	channel, err := s.Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to recieve two messages
+	// This will also test the reconnection logic, as the mock server closes the connection after sending the message
+	msg := <-channel
+	if !reflect.DeepEqual(msg, fixture) {
+		t.Errorf("got unexpected result, wanted %+v, got %+v", msg, fixture)
+	}
+
+	cancel()
+
+	// Second read, blocks until context close
+	<-channel
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/mullvad/wg-manager
 go 1.15
 
 require (
-	github.com/DMarby/jitter v0.0.0-20190312004500-d77fd504dcfa
 	github.com/coreos/go-iptables v0.6.0
 	github.com/digineo/go-ipset/v2 v2.2.1
+	github.com/gerifield/jitter v0.0.0-20210712212738-f4d51d839797
 	github.com/google/go-cmp v0.5.5
 	github.com/infosum/statsd v2.1.2+incompatible
 	github.com/jamiealquiza/envy v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DMarby/jitter v0.0.0-20190312004500-d77fd504dcfa h1:NtaE9hLsBcU0LhFSV1rl2iQLpfUepj2MYXt9NBBMXUg=
-github.com/DMarby/jitter v0.0.0-20190312004500-d77fd504dcfa/go.mod h1:j0Yp6kL88yADKYqXdmnzxZSCVXQ5lbd/hXNv8eE+PbQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -44,6 +42,8 @@ github.com/digineo/go-ipset/v2 v2.2.1 h1:k6skY+0fMqeUjjeWO/m5OuWPSZUAn7AucHMnQ1M
 github.com/digineo/go-ipset/v2 v2.2.1/go.mod h1:wBsNzJlZlABHUITkesrggFnZQtgW5wkqw1uo8Qxe0VU=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gerifield/jitter v0.0.0-20210712212738-f4d51d839797 h1:0DY0g/EibY6kCzB/5H54vnnX9VSI26K8QUc6DYJKNwc=
+github.com/gerifield/jitter v0.0.0-20210712212738-f4d51d839797/go.mod h1:1WA0o61GT2YRfo7OZQIrHPc71flhEUTavloCj1p5L0g=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -77,7 +77,6 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
@@ -87,12 +86,9 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -141,7 +137,6 @@ github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 h1:uhL5Gw7BINiiPA
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
-github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1 h1:Q6uM1SfwyYPCBtezf829EqAqolrIGhAm6KfVx3QBRWg=
 github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1/go.mod h1:hqoO/u39cqLeBLebZ8fWdE96O7FxrAsRYhnVOdgHxok=
 github.com/jsimonetti/rtnetlink v0.0.0-20201216134343-bde56ed16391/go.mod h1:cR77jAZG3Y3bsb8hF6fHJbFoyFukLFOkQ98S0pQz3xw=
 github.com/jsimonetti/rtnetlink v0.0.0-20201220180245-69540ac93943/go.mod h1:z4c53zj6Eex712ROyh8WI0ihysb5j2ROyV42iNogmAs=
@@ -156,7 +151,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.2 h1:2KCfW3I9M7nSc5wOqXAlW2v2U6v+w6cbjvbfp+OykW8=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
@@ -184,10 +178,8 @@ github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/mdlayher/netlink v1.1.1/go.mod h1:WTYpFb/WTvlRJAyKhZL5/uy69TDDpHHu2VZmb2XgV7o=
-github.com/mdlayher/netlink v1.1.2-0.20201013204415-ded538f7f4be h1:7JeFwhE5SIdgKRd0qnqjOYJxY8AML8x/j+/qvFZ8R+c=
 github.com/mdlayher/netlink v1.1.2-0.20201013204415-ded538f7f4be/go.mod h1:WTYpFb/WTvlRJAyKhZL5/uy69TDDpHHu2VZmb2XgV7o=
 github.com/mdlayher/netlink v1.2.0/go.mod h1:kwVW1io0AZy9A1E2YYgaD4Cj+C+GPkU6klXCMzIJ9p8=
-github.com/mdlayher/netlink v1.2.1 h1:Q5xDCtos3xv72vqzjuAh5Ns/IUlFfoy+948yBNSktTc=
 github.com/mdlayher/netlink v1.2.1/go.mod h1:bacnNlfhqHqqLo4WsYeXSqfyXkInQ9JneWI68v1KwSU=
 github.com/mdlayher/netlink v1.2.2-0.20210123213345-5cc92139ae3e/go.mod h1:bacnNlfhqHqqLo4WsYeXSqfyXkInQ9JneWI68v1KwSU=
 github.com/mdlayher/netlink v1.3.0/go.mod h1:xK/BssKuwcRXHrtN04UBkwQ6dY9VviGGuriDdoPSWys=
@@ -215,7 +207,6 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -247,7 +238,6 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -261,7 +251,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/ti-mo/netfilter v0.2.0 h1:mMZ70vvHTlY9y8ElWflp5nVN5kkUDvm6D1JXRgartKI=
 github.com/ti-mo/netfilter v0.2.0/go.mod h1:8GbBGsY/8fxtyIdfwy29JiluNcPK4K7wIT+x42ipqUU=
 github.com/ti-mo/netfilter v0.4.0 h1:rTN1nBYULDmMfDeBHZpKuNKX/bWEXQUhe02a/10orzg=
 github.com/ti-mo/netfilter v0.4.0/go.mod h1:V54q75mUx8CNA2JnFl+wv9iZ5+JP9nCcRlaFS5OZSRM=
@@ -274,9 +263,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
-go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -329,7 +316,6 @@ golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210504132125-bbd867fde50d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -371,7 +357,6 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201218084310-7d0127a74742/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210123111255-9b0068b26619/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210216163648-f7da38b97c65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309040221-94ec62e08169/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -387,7 +372,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -408,7 +392,6 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -447,10 +430,8 @@ gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -170,8 +170,8 @@ func main() {
 	select {
 	case <-finished:
 	case <-time.After(5 * time.Second):
-		log.Println("max wait time reached")
-		os.Exit(1)
+		log.Println("max wait time reached, forced exit")
+		// os.Exit(1) // Optionally we could have an exit code here, but this won't run the defers (that needs a workaround)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -111,15 +110,14 @@ func main() {
 		log.Fatalf("error initializing portforwarding %s", err)
 	}
 
-	// Set up context for shutting down
-	shutdownCtx, shutdown := context.WithCancel(context.Background())
-	defer shutdown()
-
 	// Run an initial synchronization
 	synchronize()
 
 	// Run an initial count of peers
 	countPeers()
+
+	// Set up context for shutting down
+	shutdownCtx, shutdown := context.WithCancel(context.Background())
 
 	// Set up a connection to receive add/remove events
 	s := subscriber.Subscriber{
@@ -129,10 +127,8 @@ func main() {
 		Channel:  *mqChannel,
 		Metrics:  metrics,
 	}
-	eventChannel := make(chan subscriber.WireguardEvent, 1024)
-	defer close(eventChannel)
 
-	err = s.Subscribe(shutdownCtx, eventChannel)
+	eventChannel, err := s.Subscribe(shutdownCtx)
 	if err != nil {
 		log.Fatal("error connecting to message-queue", err)
 	}
@@ -141,7 +137,10 @@ func main() {
 	countPeersTicker := jitter.NewTicker(*countPeerInterval, time.Microsecond)
 	synchronizationTicker := jitter.NewTicker(*synchronizationInterval, *delay)
 	resetHandshakeTicker := jitter.NewTicker(*resetHandshakeInterval, time.Microsecond)
+	finished := make(chan struct{})
 	go func() {
+		defer close(finished)
+
 		for {
 			select {
 			case msg := <-eventChannel:
@@ -165,8 +164,15 @@ func main() {
 	}()
 
 	// Wait for shutdown or error
-	err = waitForInterrupt(shutdownCtx)
-	log.Printf("shutting down: %s", err)
+	waitForInterrupt(shutdown)
+
+	log.Println("shutting down, wait for graceful shutdown")
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		log.Println("max wait time reached")
+		os.Exit(1)
+	}
 }
 
 func handleEvent(event subscriber.WireguardEvent) {
@@ -237,13 +243,9 @@ func resetHandshake() {
 	wg.ResetPeers()
 }
 
-func waitForInterrupt(ctx context.Context) error {
+func waitForInterrupt(cancel context.CancelFunc) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	select {
-	case sig := <-c:
-		return fmt.Errorf("received signal %s", sig)
-	case <-ctx.Done():
-		return errors.New("canceled")
-	}
+	<-c
+	cancel()
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/DMarby/jitter"
+	"github.com/gerifield/jitter"
 	"github.com/infosum/statsd"
 	"github.com/jamiealquiza/envy"
 	"github.com/mullvad/wg-manager/api"
@@ -171,7 +171,6 @@ func main() {
 	case <-finished:
 	case <-time.After(5 * time.Second):
 		log.Println("max wait time reached, forced exit")
-		// os.Exit(1) // Optionally we could have an exit code here, but this won't run the defers (that needs a workaround)
 	}
 }
 


### PR DESCRIPTION
## Preface

First of all, I have to tell you that I love your product and am very happy to use it.
Also, I planned to make a small and simple Wireguard configurator software like this (but using an HTTP API instead of Redis events) and was very happy to found this.

I wanted to contribute a bit to this one because I felt it might be useful. But feel free to just cancel the PR or add some comments. (No hard feelings if you don't need this. :) )

## Changes

### Subscription
As I went through the code recognized, the subscription logic part does not respect the context which it receives, so it could stuck in a reconnect loop even if the context is already closed.
I quickly added a test and tried to unfold the logic a bit.

I also like to use goroutines, but it makes a code a bit harder to follow and it's very easy to leak some of them (due to the more complex code). I had a bit hard time following the logic of why and how these processes are created so I wanted to simplify this.
Now instead of starting a goroutine for each reconnect (then for the reads) we'll have a single process for the reads and the reconnect will just "replace" the old connection variable with a new one.
I tried to keep this part as simple as possible and it'll now stop the reconnecting if the context is closed.


### Main shutdown
After I was finished with that part I recognized, the shutdown itself won't really wait for the goroutine in the main function.
The `waitForInterrupt` function (as the name suggests) will wait for an interrupt then just return from the main. The defers will run and even the `shutdown` `CancelFunc` will be called, but there's the `case <-shutdownCtx.Done()` part in the goroutine which will probably be called or not. (It depends on the actual run.)

I went after this part and tried to add a channel that could signal the main function that everything is ready/cleared, but still kept a max. amount to prevent some very long cleanups/random hangups.

#### Planned improvement
One thing I would improve here is the waiting for the subscription part. Now the context close will be respected, but we won't wait for the actual stop here.
I plan to add a very simple `Wait()` method for the `Subscriber` which will return (open/closed channel could be perfect here) if the Subscriber stopped and I'd call this in the `case <-shutdownCtx.Done()` in the `main.go`.

That way we could make sure, everything is finished cleanly. (Also we could do a clean websocket teardown with different messages/log a different event etc.)

_I'd be happy to add this part if you'd like to._


### Jitter implementation related to the shutdown
As I tried the new implementation of course the `forced exit` part kicked in. I went into details and found that the program was stopped at the `countPeersTicker.Stop()` part in the shutdown process.
I checked the Jitter implementation and found the issue. The `Stop` would only return when we are between 2 `sleep()` calls and because of the "randomness" of the `select` it could take up multiple sleep calls.
I'm not sure if that was intentional or not, but I've forked that lib and modified the implementation to close the channel.
It won't block anymore (if that's a requirement then it could be added) and now the shutdown was working properly.

##### Improvement suggestion
As I see you already tried to use your fork for this (I'm not sure why it was reverted), I'd even go a bit further and suggest using a bit more maintained solution, for example: https://github.com/lthibault/jitterbug (I miss the tests for this lib, but anyway it's just an example.)


## Closing notes

Thank you for reading through this, if you have any questions feel free to ask or PM me.
I'd be happy to help/contribute to any of your Go projects (but as I see you went mostly on the Rust way :) ).

Have a nice day!
